### PR TITLE
Correctly reference the ebloom priv dir

### DIFF
--- a/src/ebloom.erl
+++ b/src/ebloom.erl
@@ -54,14 +54,17 @@
 -spec deserialize(binary()) -> {ok, reference()}.
 
 init() ->
-    SoName = case code:priv_dir(ebloom) of
-                 {error, bad_name} ->
-                     Path0 = filename:dirname(code:which(?MODULE)),
-                     Path1 = filename:absname_join(Path0, ".."),
-                     filename:join([Path1, "priv", "ebloom_nifs"]);
-                 Dir ->
-                     filename:join(Dir, "ebloom_nifs")
-             end,
+    case code:priv_dir(ebloom) of
+        {error, bad_name} ->
+            case code:which(?MODULE) of
+                Filename when is_list(Filename) ->
+                    SoName = filename:join([filename:dirname(Filename),"../priv", "ebloom_nifs"]);
+                _ ->
+                    SoName = filename:join("../priv", "ebloom_nifs")
+            end;
+        Dir ->
+            SoName = filename:join(Dir, "ebloom_nifs")
+    end,
     erlang:load_nif(SoName, 0).
 
 new(_Count, _FalseProb, _Seed) ->


### PR DESCRIPTION
The init function currently does not reference the priv dir correctly when `code:priv_dir/1` returns `{error, bad_name}`.
### Current behavior

```
git clone git://github.com/basho/ebloom.git
cd ebloom
make
erl -pa ebin

Eshell V5.7.5  (abort with ^G)
1> ebloom:new(5, 0.01, 123).
** exception error: undefined function ebloom:new/3
2> 
=ERROR REPORT==== 25-Feb-2011::20:27:36 ===
The on_load function for module ebloom returned {error,
                                             {load_failed,
                                              "Failed to load NIF library: 'dlopen(../priv/ebloom_nifs.so, 2): image not found'"}}
```
### Fixed behavior

```
erl -pa ebin

Eshell V5.7.5  (abort with ^G)
1> ebloom:new(5, 0.01, 123).
{ok,<<>>}
```
