### PR TITLE
Fix linking on *BSD.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,7 +3,7 @@
 
 {port_envs, [
              %% Make sure to link -lstdc++ on linux or solaris
-             {"(linux|solaris)", "LDFLAGS", "$LDFLAGS -lstdc++"},
+             {"(linux|solaris|freebsd|netbsd|openbsd|dragonfly)", "LDFLAGS", "$LDFLAGS -lstdc++"},
 
              %% Solaris specific flags
              {"solaris.*-64$", "CXXFLAGS", "-D_REENTRANT -m64"},


### PR DESCRIPTION
LDFLAGS="-lstd++" should be probably added on all platforms.
